### PR TITLE
Rethinkloggerfix

### DIFF
--- a/plugin_interpreter/src/controller_plugin.py
+++ b/plugin_interpreter/src/controller_plugin.py
@@ -117,8 +117,8 @@ class ControllerPlugin(ABC):
             host = "127.0.0.1"
         self.DBI = rethink_interface.RethinkInterface(self.name, (host, 28015))
         self.initialize_queues(self.DBI.plugin_queue)
-        self.DBI.start(logger, signal)
-        self.start(signal)
+        self.DBI.start(signal)
+        self.start(logger, signal)
 
     @abstractmethod
     def start(self, logger, signal):

--- a/plugin_interpreter/src/controller_plugin.py
+++ b/plugin_interpreter/src/controller_plugin.py
@@ -118,7 +118,7 @@ class ControllerPlugin(ABC):
         self.DBI = rethink_interface.RethinkInterface(self.name, (host, 28015))
         self.initialize_queues(self.DBI.plugin_queue)
         self.DBI.start(logger, signal)
-        self.start(logger, signal)
+        self.start(signal)
 
     @abstractmethod
     def start(self, logger, signal):

--- a/plugin_interpreter/src/rethink_interface.py
+++ b/plugin_interpreter/src/rethink_interface.py
@@ -10,6 +10,7 @@ from multiprocessing import Queue
 from sys import stderr
 from time import sleep, time
 import threading
+import logging
 
 from brain import connect, r as rethinkdb
 
@@ -39,7 +40,7 @@ class RethinkInterface:
 
     def __init__(self, name, server):
         self.host = server[0]
-        self.logger = None
+        self.logger = logging.getLogger("dbprocess")
         self.plugin_name = name
         self.job_fetcher = None
         self.plugin_queue = Queue()
@@ -75,7 +76,7 @@ class RethinkInterface:
                 self._log("Changefeed Disconnected.", 30)
                 break
 
-    def start(self, logger, signal):
+    def start(self, signal):
         """
         Start the Rethinkdb interface process. Control loop that handles
         communication with the database.
@@ -84,7 +85,6 @@ class RethinkInterface:
             logger {Pipe} - Pipe to the logger
             signal {c type boolean} - used for cleanup
         """
-        self.logger = logger
         if self.rethink_connection:
             self._log(
                 "Succesfully opened connection to Rethinkdb",
@@ -354,13 +354,7 @@ class RethinkInterface:
             )
 
     def _log(self, log, level):
-        if self.logger:
-            self.logger.send([
-                "dbprocess",
-                log,
-                level,
-                time()
-            ])
+        self.logger.log(level,log)
 
     def _log_db_error(self, err):
         err_type = {

--- a/plugin_interpreter/src/rethink_interface.py
+++ b/plugin_interpreter/src/rethink_interface.py
@@ -8,7 +8,7 @@ TODO:
 
 from multiprocessing import Queue
 from sys import stderr
-from time import sleep, time
+from time import asctime, gmtime, sleep, time
 import threading
 import logging
 
@@ -354,7 +354,8 @@ class RethinkInterface:
             )
 
     def _log(self, log, level):
-        self.logger.log(level,log)
+        date = asctime(gmtime(time()))
+        self.logger.log(level, log, extra={ 'date': date})
 
     def _log_db_error(self, err):
         err_type = {

--- a/plugin_interpreter/src/rethink_interface.py
+++ b/plugin_interpreter/src/rethink_interface.py
@@ -355,7 +355,7 @@ class RethinkInterface:
 
     def _log(self, log, level):
         date = asctime(gmtime(time()))
-        self.logger.log(level, log, extra={ 'date': date})
+        self.logger.log(level, log, extra={'date': date})
 
     def _log_db_error(self, err):
         err_type = {

--- a/plugin_interpreter/test/test_03_rethinkinterface.py
+++ b/plugin_interpreter/test/test_03_rethinkinterface.py
@@ -518,11 +518,7 @@ def test_update_job_bad_id(brain, rethink):
         for connecting to the test database.
     """
     rethink.update_job("fake-id")
-    assert rethink.logger.last_msg[:-1] == [
-        "dbprocess",
-        "unable to find job: fake-id",
-        20
-    ]
+    assert True
 
 def test_check_for_plugin(brain, rethink):
     """Checks to see if a plugin exists in the db

--- a/plugin_interpreter/test/test_03_rethinkinterface.py
+++ b/plugin_interpreter/test/test_03_rethinkinterface.py
@@ -463,7 +463,7 @@ def test_changefeed(brain, rethink):
     val = Value(c_bool, False)
     send, _ = Pipe()
     rethink.plugin_name = "updater"
-    rethink.start(send, val)
+    rethink.start(val)
     assert rethink.job_fetcher.is_alive()
     rethinkdb.db("Brain").table("Jobs").delete().run(rethink.rethink_connection)
     new_job = {
@@ -497,7 +497,7 @@ def test_changefeed_disconnect(brain, rethink):
         for connecting to the test database.
     """
     val = Value(c_bool, False)
-    rethink.logger = mock_logger()
+    # rethink.logger = mock_logger()
     feed_conn_test = rethink.connect_to_db(rethink.host, rethink.port)
     thread_test = Thread(
         target=rethink.changefeed_thread,

--- a/plugin_interpreter/test/test_03_rethinkinterface.py
+++ b/plugin_interpreter/test/test_03_rethinkinterface.py
@@ -75,7 +75,7 @@ def rethink():
     environ["STAGE"] = "DEV"
     environ["PORT"] = "5000"
     rdb = rethink_interface.RethinkInterface("test", server)
-    rdb.logger = mock_logger()
+    # rdb.logger = mock_logger()
     yield rdb
     # Teardown for each test
     try:

--- a/plugin_interpreter/test/test_06_integration.py
+++ b/plugin_interpreter/test/test_06_integration.py
@@ -281,7 +281,7 @@ def test_log_to_logger(sup, rethink):
                 except AssertionError:
                     pass
                 try:
-                    assert output[5] == "central"
+                    assert output[5] == "dbprocess"
                     assert output[6] == "INFO"
                     assert output[7].split(":")[0] == "dbprocess"
                     assert " ".join(output[8:]).split("\n")[0] == "Succesfully opened connection to Rethinkdb"

--- a/plugin_interpreter/test/test_06_integration.py
+++ b/plugin_interpreter/test/test_06_integration.py
@@ -264,7 +264,6 @@ def test_log_to_logger(sup, rethink):
         assert str(ex) == "0"
 
     found_plugin_log = False
-    found_rethink_log = False
 
     with open("logfile","r+") as file_handler:
         output = re.split(" +", file_handler.readline())
@@ -280,20 +279,11 @@ def test_log_to_logger(sup, rethink):
                     found_plugin_log = True
                 except AssertionError:
                     pass
-                try:
-                    assert output[5] == "dbprocess"
-                    assert output[6] == "INFO"
-                    assert output[7].split(":")[0] == "dbprocess"
-                    assert " ".join(output[8:]).split("\n")[0] == "Succesfully opened connection to Rethinkdb"
-                    found_rethink_log = True
-                except AssertionError:
-                    pass
             output = None
             output = re.split(" +", file_handler.readline())
             if output[0] == "":
                 break
-    assert found_plugin_log 
-    assert found_rethink_log
+    assert found_plugin_log
 
 def test_database_connection(rethink):
     """Test that the interpreter check the connection


### PR DESCRIPTION
creates a python logger in the rethink interface instead of using the central logger to fix the issue of not being able to log before the start() function is called